### PR TITLE
I've aligned the Java version to 17 and improved Docker port handling.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use OpenJDK 21 as base image
-FROM openjdk:21-jdk-slim
+# Use OpenJDK 17 as base image
+FROM openjdk:17-jdk-slim
 
 # Set working directory
 WORKDIR /app
@@ -24,5 +24,5 @@ RUN ./mvnw clean package -DskipTests
 EXPOSE 8080
 
 # Run the application
-CMD ["java", "-jar", "target/bluechat-v2-0.0.1-SNAPSHOT.jar", "--server.port=8080"]
+CMD ["java", "-jar", "target/bluechat-v2-0.0.1-SNAPSHOT.jar", "--server.port=${PORT:-8080}"]
 

--- a/railway.toml
+++ b/railway.toml
@@ -6,7 +6,7 @@ startCommand = "java -jar target/bluechat-v2-0.0.1-SNAPSHOT.jar"
 restartPolicyType = "always"
 
 [environments.production.variables]
-JAVA_VERSION = "21"
+JAVA_VERSION = "17"
 MAVEN_ARGS = "clean package -DskipTests"
 
 [environments.production.deploy]

--- a/render.yaml
+++ b/render.yaml
@@ -9,6 +9,8 @@ services:
         value: "-Xmx300m -Xms300m"
       - key: SERVER_PORT
         value: "$PORT"
+      - key: JAVA_VERSION
+        value: "17"
     scaling:
       minInstances: 1
       maxInstances: 1

--- a/system.properties
+++ b/system.properties
@@ -1,2 +1,2 @@
-java.runtime.version=21
+java.runtime.version=17
 


### PR DESCRIPTION
The project's `pom.xml` specifies Java 17. However, various deployment configuration files (`system.properties`, `railway.toml`, `Dockerfile`, `render.yaml`) were configured to use or expected Java 21. This mismatch can lead to build failures or runtime errors (UnsupportedClassVersionError).

This commit aligns all relevant configurations to use Java 17:
- Updated `system.properties` to `java.runtime.version=17`.
- Updated `railway.toml` to specify `JAVA_VERSION = "17"`.
- Updated `Dockerfile` to use `openjdk:17-jdk-slim` base image.
- Added `JAVA_VERSION: "17"` environment variable to `render.yaml`.

Additionally, the `Dockerfile`'s CMD has been updated to use the `PORT` environment variable for port binding (`--server.port=${PORT:-8080}`), making the Docker image more platform-agnostic. The `render-build.sh` is expected to adapt to the Java 17 environment provided by Render.

These changes ensure consistency and should resolve deployment issues stemming from Java version conflicts.